### PR TITLE
OCPCLOUD-2642: Fix Dockerfile context for CI

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,7 +1,9 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
 
 WORKDIR /build
-COPY . .
+# NOTE: We're copying v2 in like this rather than using v2 as the context
+# to avoid issues with ci-operator's working directory behavior
+COPY v2/ ./
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${GOOS} GOPROXY=${GOPROXY} go build \
   -ldflags="-w -s -X 'main.version=${VERSION}'" \
   -o=azure-service-operator \
@@ -9,7 +11,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=${GOOS} GOPROXY=${GOPROXY} go build \
 
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 
-LABEL description="Azure Service Operator"
+LABEL description="Azure Service Operator Controller Manager"
 
 COPY --from=builder /build/azure-service-operator /bin/azure-service-operator
 

--- a/openshift/Dockerfile.dockerignore
+++ b/openshift/Dockerfile.dockerignore
@@ -3,10 +3,10 @@
 **
 
 # Ignore everything except below
-!/go.mod
-!/go.sum
-!/vendor/**
-!/cmd/**
-!/pkg/**
-!/internal/**
-!/api/**
+!/v2/go.mod
+!/v2/go.sum
+!/v2/vendor/**
+!/v2/cmd/**
+!/v2/pkg/**
+!/v2/internal/**
+!/v2/api/**

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -21,9 +21,11 @@ binaries:
 	go build -C ${ROOT_DIR}/v2 -o aso-controller ./cmd/controller
 
 # Redefine this target since upstream uses make for v1 and task for v2.
+# NOTE: We use the repo root as the docker build context, but the Dockerfile itself
+# will pull in files from the v2 directory
 .PHONY: docker-build
 docker-build:
-	docker build -f openshift/Dockerfile --ignorefile openshift/Dockerfile.dockerignore -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) ${ROOT_DIR}/v2
+	docker build -f openshift/Dockerfile --ignorefile openshift/Dockerfile.dockerignore -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) ${ROOT_DIR}
 
 .PHONY: docker-push
 docker-push:

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -12,3 +12,6 @@ from this repository, because Openshift does not need the entire Azure API surfa
 
 CRDs are included in the CAPZ manifests, which already filters the installed CRDs
 down to only those relevant to cluster lifecycling.
+
+If you run into issues building the container image, double check the
+`openshift/Dockefile.dockerignore` file; it may be excluding something.


### PR DESCRIPTION
The builder in ci-operator doesn't set contexts in the same way that we'd expect, so update the Dockerfile and Makefile to use directories the same way ci-operator does.

Needed to get https://github.com/openshift/release/pull/55371 passing.