### PR TITLE
ART-11334: exclude v2 to ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,6 @@ cover-existing.html
 coverage-existing.txt
 report-existing.xml
 testlogs-existing.txt
-v2
+!v2/
 !v2/boilerplate.go.txt
 .git


### PR DESCRIPTION
@nrb  this PR is for fixing

            error: go: go.mod file not found in current directory or any parent
